### PR TITLE
added context to struct block rendering 

### DIFF
--- a/streamfield_tools/blocks/struct_block.py
+++ b/streamfield_tools/blocks/struct_block.py
@@ -77,12 +77,12 @@ class MultiRenditionStructBlock(StructBlock):
         rendition = self._rendition_set_config.get(
             value['render_as']
         )
+        context = self.get_context(value)
+        context['self'] = value
+        context['image_rendition'] = rendition.image_rendition or 'original'
+        context['addl_classes'] = value['addl_classes']
         return rendition.template.render(
-            {
-                'self': value,
-                'image_rendition': rendition.image_rendition or 'original',
-                'addl_classes': value['addl_classes']
-            }
+            context
         )
 
     def to_python(self, value):
@@ -123,11 +123,8 @@ class RenditionAwareStructBlock(RenditionMixIn, StructBlock):
             except AttributeError:
                 template = self.meta.template
 
-            return render_to_string(
-                template,
-                {
-                    'self': value,
-                    'image_rendition': self.rendition.image_rendition
-                    or 'original'
-                }
-            )
+
+            context = self.get_context(value)
+            context['self'] = value
+            context['image_rendition'] = rendition.image_rendition or 'original'
+            return render_to_string(template, context)


### PR DESCRIPTION
added context to the rendering for RenditionAwareStructBlock and MultiRenditionStructBlock so they can be subclassed and still have the "get_context" method work correctly.
